### PR TITLE
Add chapter index web page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Bayesian Statistics Chapters</title>
+</head>
+<body>
+  <h1>Bayesian Statistics Chapters</h1>
+  <ul>
+    <li><a href="scripts/chapter4.py">Chapter 4: Binomial Distribution</a> – explores the binomial coefficient and the distribution of a dice roll.</li>
+    <li><a href="scripts/chapter5.py">Chapter 5: Beta Distribution</a> – examines the beta distribution and probabilities around 0.5.</li>
+    <li><a href="scripts/chapter9.py">Chapter 9: Beta Exercises</a> – tests coin fairness using the beta distribution.</li>
+    <li><a href="notebooks/chapter12.ipynb">Chapter 12 Notebook</a> – estimates the depth of a well by timing a dropped coin.</li>
+    <li><a href="notebooks/chapter19.ipynb">Chapter 19 Notebook</a> – evaluates the fairness of a carnival game with the Bayes factor.</li>
+    <li><a href="notebooks/chapter9c3po.ipynb">Chapter 9 C3PO Notebook</a> – shows the influence of a strong prior in a beta update.</li>
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `src/index.html` to present links to chapter scripts and notebooks.
- Translate chapter descriptions into English.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c08b4be7ac832e9887d8c00e2e06a6